### PR TITLE
Improve performance of COPY TO

### DIFF
--- a/NEWS.carto.md
+++ b/NEWS.carto.md
@@ -1,5 +1,11 @@
 # CARTO's Changelog
 
+## v1.2.0-carto.1
+Released 2018-mm-dd
+
+Bug fixes:
+ * Improves performance of COPY TO by sending bigger chunks through low level `push()`. See https://github.com/CartoDB/node-pg-copy-streams/pull/1
+
 ## v1.2.0
 Released 2016-08-22
 

--- a/copy-to.js
+++ b/copy-to.js
@@ -44,12 +44,10 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
 
   var buffer = Buffer.alloc(chunk.length);
   var buffer_offset = 0;
-  var buffer_sent = false;
 
   this.pushBufferIfneeded = function() {
-    if(needPush && !buffer_sent && buffer_offset > 0) {
+    if (needPush && buffer_offset > 0) {
       this.push(buffer.slice(0, buffer_offset))
-      buffer_sent = true;
       buffer_offset = 0;
     }
   }


### PR DESCRIPTION
Under some circumstances, the COPY TO streamming can be CPU-bound,
particularly when PG holds the resultset in memory buffers, the network is fast, and the size
of the rows << chunk (64 KB in my linux box).

This commits improves the situation by creating a buffer of `chunk`
size and fitting in as many rows as it can before pushing them. This
results in more balanced read and writes (in terms of size and in bigger
chunks) as well as more frequent calls to the callback, thus freeing the
main loop for other events to be processed, and therefore avoiding
starvation.

@oleurud I'd appreciate a quick review before I send it upstream. 

Here's one quick test, comparing the throughput of the health check while running the copy to:

before:
```
$ wrk2 -R 2000 http://development.localhost.lan:8080/ --latency -s simple_query.lua -d 10 -t 4
[...]
  336 requests in 10.01s, 108.61KB read
Requests/sec:     33.56
Transfer/sec:     10.85KB
```

after:
```
$ wrk2 -R 2000 http://development.localhost.lan:8080/ --latency -s simple_query.lua -d 10 -t 4
[...]
  14029 requests in 10.00s, 4.40MB read
Requests/sec:   1402.67
Transfer/sec:    450.67KB
```

In both cases the COPY TO took ~ 16 s to complete, transferring and writing about 400 MB (that is 25 MB/s).

Mind that both the healthcheck and the copy to are CPU-bound if we use the loopback network interface, so they will compete anyway for the CPU core (but in the later case the competition will be more fair).