### PR TITLE
Fix for interspersed messages

### DIFF
--- a/NEWS.carto.md
+++ b/NEWS.carto.md
@@ -1,10 +1,11 @@
 # CARTO's Changelog
 
 ## v2.2.0-carto.1
-Released 2018-mm-dd
+Released 2019-mm-dd
 
 Bug fixes:
  * Copy to: ensure stream is detached when finished
+ * Copy to: deal with interspersed messages properly. See [#9](https://github.com/CartoDB/node-pg-copy-streams/pull/9)
 
 ## v1.2.0-carto.3
 Released 2018-11-21

--- a/copy-to.js
+++ b/copy-to.js
@@ -105,7 +105,7 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
         case code.ParameterStatus:
         case code.NoticeResponse:
         case code.NotificationResponse:
-          console.log("Got an interspersed message: " + message);
+          this.emit('warning', 'Got an interspersed message: ' + message);
           break;
       }
       offset += (length - Int32Len);

--- a/copy-to.js
+++ b/copy-to.js
@@ -95,13 +95,20 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
     length = chunk.readUInt32BE(offset+Byte1Len)
     if(chunk.length >= (offset + Byte1Len + length)) {
       offset += Byte1Len + Int32Len
-      if (needPush) {
-        var row = chunk.slice(offset, offset + length - Int32Len)
-        this.rowCount++
-        row.copy(buffer, buffer_offset);
-        buffer_offset += row.length;
+      var message = chunk.slice(offset, offset + length - Int32Len)
+      switch(messageCode) {
+        case code.CopyData:
+          this.rowCount++;
+          message.copy(buffer, buffer_offset);
+          buffer_offset += message.length;
+          break;
+        case code.ParameterStatus:
+        case code.NoticeResponse:
+        case code.NotificationResponse:
+          console.log("Got an interspersed message: " + message);
+          break;
       }
-      offset += (length - Int32Len)
+      offset += (length - Int32Len);
     } else {
       // we need more chunks for a complete message
       break;

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -151,6 +151,24 @@ var testInterspersedMessageDoesNotBreakCopyFlow = function() {
 };
 testInterspersedMessageDoesNotBreakCopyFlow();
 
+var testInterspersedMessageEmitsWarnign = function() {
+  var toClient = client();
+  toClient.query(warnAndReturnOne, (err, res) => {
+    var q = "COPY (SELECT * FROM pg_temp.test_warn_return_one()) TO STDOUT WITH (FORMAT 'csv', HEADER true)";
+    var stream = toClient.query(copy(q));
+    var done = gonna('got expected warning event', 1000, function() {
+      toClient.end();
+    });
+
+    stream.on('warning', function(msg) {
+      assert(msg.match(/Got an interspersed message:.*WARNING.*hey, this is returning one/),
+             'did not get expected warning for interspersed message in COPY TO');
+      done();
+    })
+  });
+};
+testInterspersedMessageEmitsWarnign();
+
 var testClientReuse = function() {
   var c = client();
   var limit = 100000;

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -117,6 +117,40 @@ var testNoticeResponse = function() {
 }
 testNoticeResponse();
 
+var warnAndReturnOne = `
+CREATE OR REPLACE FUNCTION pg_temp.test_warn_return_one()
+RETURNS INTEGER
+AS $$
+BEGIN
+  RAISE WARNING 'hey, this is returning one';
+  RETURN 1;
+END;
+$$ LANGUAGE plpgsql`;
+
+var testInterspersedMessageDoesNotBreakCopyFlow = function() {
+  var toClient = client();
+  toClient.query(warnAndReturnOne, (err, res) => {
+    var q = "COPY (SELECT * FROM pg_temp.test_warn_return_one()) TO STDOUT WITH (FORMAT 'csv', HEADER true)";
+    var stream = toClient.query(copy(q));
+    var done = gonna('got expected COPY TO payload', 1000, function() {
+      toClient.end();
+    });
+
+    stream.pipe(concat(function(buf) {
+      res = buf.toString('utf8')
+    }));
+
+    stream.on('end', function() {
+      var expected = "test_warn_return_one\n1\n";
+      assert.equal(res, expected);
+      // note the header counts as a row
+      assert.equal(stream.rowCount, 2, 'should have rowCount = 2 but got ' + stream.rowCount);
+      done();
+    });
+  });
+};
+testInterspersedMessageDoesNotBreakCopyFlow();
+
 var testClientReuse = function() {
   var c = client();
   var limit = 100000;


### PR DESCRIPTION
The way the messages were buffered caused interspersed messages to be
inserted in the middle of CopyData messages disrupting the normal COPY
TO flow.

This fixes it by consuming (adjusting offsets as appropriate) and just
logging them to console, effectively discarding them from the COPY
flow.

This is a possible fix for https://github.com/CartoDB/CartoDB-SQL-API/issues/583

I tested it by creating this function:

```sql
-- File /tmp/test_return_one.psql
CREATE OR REPLACE FUNCTION test_return_one()
RETURNS INTEGER
AS $$
BEGIN
  RAISE WARNING 'hey, this is returning one';
  RETURN 1;
END;
$$ LANGUAGE plpgsql;
```

and invoking it through the SQL API:
```shell
BASE_URL=http://development.localhost.lan:8080
QUERY="COPY+(SELECT+*+FROM+test_return_one())+to+STDOUT+WITH+(FORMAT+'csv',+HEADER+true)"

curl --output - "${BASE_URL}/api/v1/sql/copyto?api_key=${API_KEY}&q=${QUERY}"
```

Before the fix it yields this:
```
test_return_one
SWARNINGVWARNINGC01000Mhey, this is returning oneWPL/pgSQL function test_return_one() line 3 at RAISEFpl_exec.cL3337Rexec_stmt_raise1
```

After the fix, it works as expected:
```
$ curl --output - "${BASE_URL}/api/v1/sql/copyto?api_key=${API_KEY}&q=${QUERY}"
test_return_one
1
```

and the logs show the WARNING on the console:
```
[2019-06-04 12:31:03.746] [INFO] console - Using Node.js v10.15.1
[2019-06-04 12:31:03.747] [INFO] console - Using configuration file "/home/rtorre/src/CartoDB-SQL-API/config/environments/development.js"
[2019-06-04 12:31:03.747] [INFO] console - CartoDB SQL API 3.1.0 listening on 127.0.0.1:8080 PID=17134 (development)
[2019-06-04 12:31:17.369] [INFO] console - Got an interspersed message: SWARNINGVWARNINGC01000Mhey, this is returning oneWPL/pgSQL function test_return_one() line 3 at RAISEFpl_exec.cL3337Rexec_stmt_raise
[2019-06-04 12:31:17.374] [INFO] [default] - [Tue, 04 Jun 2019 10:31:17 GMT] 127.0.0.1 GET development.localhost.lan:8080/api/v1/sql/copyto?api_key=3bc90e2062d794f63c35aca9135db65b0bbe7e53&q=COPY+(SELECT+*+FROM+test_return_one())+to+STDOUT+WITH+(FORMAT+'csv',+HEADER+true) 200 32 ms -> application/octet-stream (undefined) (undefined)
```

This is not perfect, but it may be better than what we have now.

IMHO "perfection" would require parsing all the 3 message types properly, and "bubble them" up the call stack to the app, for it to decide what to do.

Then the SQL API will have severe limitations to convey that WARNING or whatever, protocol-wise, cause by the time the WARNING is received, http headers are already sent and there's just one byte stream to pass the COPY payload to clients.

@dgaubert what do you think?